### PR TITLE
Add CSV persistence utilities for run telemetry

### DIFF
--- a/services/persist.py
+++ b/services/persist.py
@@ -1,1 +1,177 @@
-"""Persistence utilities for session management and telemetry storage."""
+"""CSV persistence layer for telemetry runs with a stable schema contract.
+
+This module is responsible for writing and reading run telemetry in
+``data/runs.csv``. The header order defined in :data:`CSV_HEADERS` must remain
+stable because external analytics tooling relies on that schema.
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+from agents.models import RunRecord
+
+CSV_PATH = Path("data/runs.csv")
+CSV_HEADERS = [
+    "ts",
+    "agent_name",
+    "model",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "latency_ms",
+    "cost_usd",
+    "experiment_id",
+    "task_label",
+    "run_notes",
+    "streaming",
+    "model_list_source",
+    "tool_web_enabled",
+    "web_status",
+    "aborted",
+]
+
+_INT_FIELDS = {"prompt_tokens", "completion_tokens", "total_tokens", "latency_ms"}
+_FLOAT_FIELDS = {"cost_usd"}
+_BOOL_FIELDS = {"streaming", "tool_web_enabled", "aborted"}
+
+
+def init_csv() -> None:
+    """Initialize CSV file with headers if it doesn't exist"""
+
+    if CSV_PATH.exists():
+        return
+
+    CSV_PATH.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with CSV_PATH.open("w", newline="", encoding="utf-8") as file:
+            writer = csv.DictWriter(file, fieldnames=CSV_HEADERS)
+            writer.writeheader()
+    except OSError as exc:  # pragma: no cover - filesystem failure paths
+        raise RuntimeError(f"Failed to initialize CSV at {CSV_PATH}: {exc}") from exc
+
+
+def append_run(record: RunRecord) -> None:
+    """Append a run record to the CSV file"""
+
+    init_csv()
+    row = record.model_dump()
+    row["ts"] = record.ts.isoformat()
+
+    serialised_row = {header: row.get(header, "") for header in CSV_HEADERS}
+
+    try:
+        with CSV_PATH.open("a", newline="", encoding="utf-8") as file:
+            writer = csv.DictWriter(file, fieldnames=CSV_HEADERS)
+            writer.writerow(serialised_row)
+    except OSError as exc:  # pragma: no cover - filesystem failure paths
+        raise RuntimeError(f"Failed to append run record: {exc}") from exc
+
+
+def _coerce_bool(value: str | bool | None) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "y"}
+
+
+def _coerce_int(value: Any) -> int:
+    if value in ("", None):
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_float(value: Any) -> float:
+    if value in ("", None):
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def load_recent_runs(limit: int = 10) -> list[RunRecord]:
+    """Load the N most recent runs from CSV"""
+
+    if not CSV_PATH.exists():
+        return []
+
+    records: list[RunRecord] = []
+    try:
+        with CSV_PATH.open("r", newline="", encoding="utf-8") as file:
+            reader = csv.DictReader(file)
+            for row in reader:
+                try:
+                    parsed = _parse_row(row)
+                except ValueError:
+                    # Skip rows that cannot be parsed into a valid RunRecord
+                    continue
+                records.append(RunRecord(**parsed))
+    except OSError as exc:  # pragma: no cover - filesystem failure paths
+        raise RuntimeError(f"Failed to read CSV at {CSV_PATH}: {exc}") from exc
+
+    return records[-limit:]
+
+
+def _parse_row(row: dict[str, Any]) -> dict[str, Any]:
+    parsed: dict[str, Any] = {key: row.get(key, "") for key in CSV_HEADERS}
+
+    ts_value = parsed.get("ts", "")
+    if ts_value in (None, ""):
+        raise ValueError("Missing timestamp in CSV row")
+    try:
+        parsed["ts"] = datetime.fromisoformat(ts_value)
+    except ValueError as exc:
+        raise ValueError("Invalid timestamp format") from exc
+
+    for field in _INT_FIELDS:
+        parsed[field] = _coerce_int(parsed.get(field))
+
+    for field in _FLOAT_FIELDS:
+        parsed[field] = _coerce_float(parsed.get(field))
+
+    for field in _BOOL_FIELDS:
+        parsed[field] = _coerce_bool(parsed.get(field))
+
+    # Normalise optional string fields to empty string when missing.
+    for field in {"experiment_id", "task_label", "run_notes", "model_list_source", "web_status", "agent_name", "model"}:
+        parsed[field] = (parsed.get(field) or "").strip()
+
+    return parsed
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    record = RunRecord(
+        ts=datetime.now(),
+        agent_name="TestAgent",
+        model="openai/gpt-3.5-turbo",
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30,
+        latency_ms=1500,
+        cost_usd=0.001,
+        streaming=True,
+        model_list_source="fallback",
+    )
+
+    init_csv()
+    append_run(record)
+    print(f"✅ Record written to {CSV_PATH}")
+
+    recent = load_recent_runs(limit=5)
+    print(f"✅ Loaded {len(recent)} recent runs")
+
+    if CSV_PATH.exists():
+        print(f"✅ CSV exists at: {CSV_PATH.absolute()}")


### PR DESCRIPTION
## Summary
- implement CSV initialization and append helpers to persist run telemetry
- add robust row parsing that enforces the stable schema when loading recent runs
- include a manual test harness to verify CSV creation and reading

## Testing
- python services/persist.py

------
https://chatgpt.com/codex/tasks/task_e_68db39005f888322bb4524b7c5ce892f