### PR TITLE
feat: connect Gradio chat to agent runtime

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-import os
+import asyncio
+import time
+from datetime import datetime
+from os import getenv
 import sys
 from pathlib import Path
 from typing import Any
@@ -14,12 +17,14 @@ if str(ROOT_DIR) not in sys.path:
 import gradio as gr
 from dotenv import load_dotenv
 
-from agents.models import AgentConfig
+from agents.models import AgentConfig, RunRecord
+from agents.runtime import build_agent, run_agent
+from services.persist import append_run, init_csv
 
 load_dotenv()
 
 # Security: never print the API key; warn the operator so they can add it securely.
-if not os.getenv("OPENROUTER_API_KEY"):
+if not getenv("OPENROUTER_API_KEY"):
     print(
         "Warning: OPENROUTER_API_KEY is not set. The UI will run in limited mode until a key is provided."
     )
@@ -31,59 +36,100 @@ DEFAULT_AGENT_CONFIG = AgentConfig(
 )
 
 
-def handle_build_agent(
-    agent_name: str,
-    model_id: str,
-    system_prompt: str,
-    temperature: float,
-    top_p: float,
-    web_tool_enabled: bool,
-    _config_state: AgentConfig,
-    _agent_state: Any,
-) -> tuple[AgentConfig, str, str, Any]:
-    """Placeholder build handler that updates config state and telemetry banner."""
+def _web_badge_html(enabled: bool) -> str:
+    """Render the HTML badge describing the web tool state."""
 
-    updated_config = AgentConfig(
-        name=agent_name,
-        model=model_id,
-        system_prompt=system_prompt,
-        temperature=temperature,
-        top_p=top_p,
-        tools=["web_fetch"] if web_tool_enabled else [],
-    )
-
-    badge_color = "#0066cc" if web_tool_enabled else "#666"
-    badge_state = "ON" if web_tool_enabled else "OFF"
-    badge_html = (
+    badge_color = "#0066cc" if enabled else "#666666"
+    badge_state = "ON" if enabled else "OFF"
+    return (
         "<span style=\"background:{color};color:white;padding:4px 8px;border-radius:4px;\">"
         "Web Tool: {state}</span>"
     ).format(color=badge_color, state=badge_state)
 
-    return (
-        updated_config,
-        "Agent building not implemented",
-        badge_html,
-        None,
+
+def build_agent_handler(
+    name: str,
+    model: str,
+    sys_prompt: str,
+    temp: float,
+    top_p: float,
+    web_enabled: bool,
+    config_state: AgentConfig,
+) -> tuple[AgentConfig, str, str, Any]:
+    """Build an agent using the runtime and update UI state."""
+
+    updated_config = AgentConfig(
+        name=name,
+        model=model,
+        system_prompt=sys_prompt,
+        temperature=temp,
+        top_p=top_p,
+        tools=["web_fetch"] if web_enabled else [],
     )
 
+    badge_html = _web_badge_html(web_enabled)
 
-def handle_send_message(
-    user_message: str,
-    history: list[dict[str, str]] | None,
-    _agent_state: Any,
-) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
-    """Placeholder chat handler that echoes a not implemented response."""
+    try:
+        agent = build_agent(updated_config, include_web=web_enabled)
+    except Exception as exc:  # pragma: no cover - runtime guard
+        error_badge = _web_badge_html("web_fetch" in config_state.tools)
+        return config_state, f"❌ Error: {exc}", error_badge, None
 
-    existing_history: list[dict[str, str]] = history or []
+    return updated_config, "✅ Agent built successfully", badge_html, agent
 
-    if not user_message.strip():
-        return existing_history, existing_history
 
-    updated_history = existing_history + [
-        {"role": "user", "content": user_message},
-        {"role": "assistant", "content": "Chat not implemented"},
-    ]
-    return updated_history, updated_history
+async def send_message_handler(
+    message: str,
+    history: list[list[str]] | None,
+    config_state: AgentConfig,
+    agent_state: Any,
+) -> tuple[list[list[str]], list[list[str]], str]:
+    """Send a chat message to the agent and persist telemetry."""
+
+    chat_history = history[:] if history else []
+    trimmed_message = message.strip()
+
+    if not trimmed_message:
+        return chat_history, chat_history, "⚠️ Enter a message to send."
+
+    if agent_state is None:
+        error_response = "⚠️ Build the agent before starting a chat."
+        chat_history.append([trimmed_message, error_response])
+        return chat_history, chat_history, error_response
+
+    start_time = time.time()
+
+    try:
+        agent_response, _usage = await run_agent(agent_state, trimmed_message)
+    except Exception as exc:  # pragma: no cover - runtime guard
+        error_text = f"❌ Agent error: {exc}"
+        chat_history.append([trimmed_message, error_text])
+        return chat_history, chat_history, error_text
+
+    latency_ms = int((time.time() - start_time) * 1000)
+    chat_history.append([trimmed_message, agent_response])
+
+    timestamp = datetime.utcnow().replace(microsecond=0)
+    web_tool_enabled = "web_fetch" in config_state.tools
+
+    record = RunRecord(
+        ts=timestamp,
+        agent_name=config_state.name,
+        model=config_state.model,
+        latency_ms=latency_ms,
+        streaming=False,
+        tool_web_enabled=web_tool_enabled,
+        web_status="ok" if web_tool_enabled else "off",
+    )
+
+    await asyncio.to_thread(append_run, record)
+
+    run_info = (
+        f"🕒 {latency_ms}ms | 🧠 {config_state.model} | "
+        f"📅 {timestamp.isoformat()}"
+    )
+
+    return chat_history, chat_history, run_info
 
 
 def create_ui() -> gr.Blocks:
@@ -133,7 +179,7 @@ def create_ui() -> gr.Blocks:
                 reset_agent = gr.Button("Reset", variant="secondary")
 
             with gr.Column(scale=2):
-                chatbot = gr.Chatbot(label="Conversation", height=600, type="messages")
+                chatbot = gr.Chatbot(label="Conversation", height=600)
                 with gr.Row():
                     user_input = gr.Textbox(label="Message", scale=4, lines=2)
                     send_btn = gr.Button("Send", scale=1)
@@ -148,7 +194,7 @@ def create_ui() -> gr.Blocks:
                 download_csv = gr.Button("Download runs.csv")
 
         build_agent.click(
-            fn=handle_build_agent,
+            fn=build_agent_handler,
             inputs=[
                 agent_name,
                 model_selector,
@@ -157,7 +203,6 @@ def create_ui() -> gr.Blocks:
                 top_p,
                 web_tool_enabled,
                 config_state,
-                agent_state,
             ],
             outputs=[
                 config_state,
@@ -168,14 +213,16 @@ def create_ui() -> gr.Blocks:
         )
 
         send_btn.click(
-            fn=handle_send_message,
-            inputs=[user_input, history_state, agent_state],
-            outputs=[chatbot, history_state],
+            fn=send_message_handler,
+            inputs=[user_input, history_state, config_state, agent_state],
+            outputs=[chatbot, history_state, run_info_display],
         )
 
     return demo
 
 
 if __name__ == "__main__":
+    init_csv()
+    print("Telemetry CSV initialized.")
     app = create_ui()
     app.launch(server_name="0.0.0.0", server_port=7860)


### PR DESCRIPTION
## Summary
- build agents from UI selections and surface status feedback and web badge updates
- run chat turns through the agent runtime, measure latency, and append telemetry to CSV
- initialize telemetry storage on startup and improve chat history rendering

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68db39f1e0208322b4647845d99f6a78